### PR TITLE
bump min python to 3.10, add np as explicit dep

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "Cython", "numpy"]
+requires = ["setuptools>=61.0", "wheel", "Cython", "numpy>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,15 +9,15 @@ authors = [
   { name="The yt project", email="yt-dev@python.org"},
 ]
 description="A repository containing some experimental packages and enhancements "
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",
 ]
-dependencies=['yt>4.2.0',]
+dependencies=['yt>4.2.0', 'numpy']
 
 [project.readme]
 file = "README.md"


### PR DESCRIPTION
This bumps the minimum python version to 3.10 (with the understanding that yt will soon bump as well), adds numpy as an explicit dependency and requires numpy>=2.0 for the build step.