### PR TITLE
Add build and publish workflow

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,0 +1,83 @@
+# based off the cookiecutter action provided by https://github.com/scientific-python/cookie
+name: wheels
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - created
+      - published
+  pull_request:
+    paths:
+      - .github/workflows/build_and_publish.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Many color libraries just need this to be set to any value, but at least
+  # one distinguishes color depth, where "3" -> "256-bit color".
+  FORCE_COLOR: 3
+
+jobs:
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build SDist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  build_wheels:
+    name: Wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pypa/cibuildwheel@v2.21
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: wheelhouse/*.whl
+
+  upload_all:
+    needs: [build_wheels, make_sdist]
+    environment: pypi
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@v1.4.3
+        with:
+          subject-path: "dist/*"
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -9,7 +9,7 @@ on:
       - published
   pull_request:
     paths:
-      - .github/workflows/build_and_publish.yml
+      - .github/workflows/build_and_publish.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -43,14 +43,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [
+          ubuntu-20.04,
+          windows-2022,
+          macos-13, # x86_64
+          macos-14, # arm64
+        ]
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pypa/cibuildwheel@v2.21
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 build-verbosity = 1
 test-extras = "test"
 test-command = [
-    "pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt -ra",
+    "pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt_experiments -ra",
 ]
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,10 +93,6 @@ combine-as-imports = true
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 build-verbosity = 1
-test-extras = "test"
-test-command = [
-    "pytest yt_experiments",
-]
 
 [tool.cibuildwheel.linux]
 archs = "x86_64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,17 @@ ignore = [
 
 [tool.ruff.isort]
 combine-as-imports = true
+
+
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
+build-verbosity = 1
+
+[tool.cibuildwheel.linux]
+archs = "x86_64"
+
+[tool.cibuildwheel.macos]
+archs = "auto"
+
+[tool.cibuildwheel.windows]
+archs = "auto64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 authors = [
   { name="The yt project", email="yt-dev@python.org"},
 ]
-description="A repository containing some experimental packages and enhancements "
+description="A repository containing some experimental packages and enhancements for yt"
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -93,6 +93,10 @@ combine-as-imports = true
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 build-verbosity = 1
+test-extras = "test"
+test-command = [
+    "pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt -ra",
+]
 
 [tool.cibuildwheel.linux]
 archs = "x86_64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ test = [
     "pytest>=6.1",
 ]
 
+[tool.setuptools]
+packages = ["yt_experiments"]
+
 [tool.pytest.ini_options]
 addopts = '''
     -s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "Cython", "numpy"]
+requires = ["setuptools>=61.0", "wheel", "Cython", "numpy>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,15 +9,15 @@ authors = [
   { name="The yt project", email="yt-dev@python.org"},
 ]
 description="A repository containing some experimental packages and enhancements "
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",
 ]
-dependencies=['yt>4.2.0',]
+dependencies=['yt>4.2.0', 'numpy']
 
 [project.readme]
 file = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,10 @@ combine-as-imports = true
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 build-verbosity = 1
+test-extras = "test"
+test-command = [
+    "pytest yt_experiments",
+]
 
 [tool.cibuildwheel.linux]
 archs = "x86_64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,10 +93,6 @@ combine-as-imports = true
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
 build-verbosity = 1
-test-extras = "test"
-test-command = [
-    "pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt_experiments -ra",
-]
 
 [tool.cibuildwheel.linux]
 archs = "x86_64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "Cython", "numpy>=2.0"]
+requires = ["setuptools>=61.0", "wheel", "Cython>=3.0.3", "numpy>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This adds a workflow to test the build process (both sdist and wheels) and upload to pypi if the action is triggered by publishing of a release on github. Just the build process will run on changes to the workflow file and on initial creation of the github release. 

have not yet set up the pypi side... but we can test the wheels build now.

based off of #12 