### PR TITLE
More project config

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -5,11 +5,13 @@ on:
   workflow_dispatch:
   release:
     types:
-      - created
       - published
   pull_request:
     paths:
       - .github/workflows/build_and_publish.yaml
+  push:
+    tags:
+      - 'v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -63,6 +65,22 @@ jobs:
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
+
+  create_gh_draft_release:
+    needs: [build_wheels, make_sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          tag: ${{ github.ref }}
+          prerelease: false
+          name: Release ${{ github.ref }}
 
   upload_all:
     needs: [build_wheels, make_sdist]

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,6 +1,10 @@
 name: Run tests
-on: [pull_request]
-
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    tags:
+      - 'v*'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yt_experiments"
-version = "0.1.0"
 authors = [
   { name="The yt project", email="yt-dev@python.org"},
 ]
@@ -18,6 +17,11 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
 ]
 dependencies=['yt>4.2.0', 'numpy']
+dynamic = ["version"]
+
+[tool.setuptools.dynamic]
+version = {attr = "yt_experiments.__version__"}
+
 
 [project.readme]
 file = "README.md"


### PR DESCRIPTION
* run both the build (without publishing) and tests on tag push
* generate a draft release on a tag push if the build passes (final publication will trigger another build and publication to pypi)
* single source version (pyproject will now read from `_version.py`)